### PR TITLE
LRQA-66891 Remove wait for Metal Component in management bar

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/MetalComponent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MetalComponent.macro
@@ -15,7 +15,7 @@ definition {
 	macro waitForManagementBar {
 		AssertVisible(locator1 = "//nav[contains(@class,'management-bar')]");
 
-		MetalComponent.waitForMetalComponent(id = '''document.querySelector("nav.management-bar").parentNode.id''');
+		//MetalComponent.waitForMetalComponent(id = '''document.querySelector("nav.management-bar").parentNode.id''');
 	}
 
 	macro waitForMetalComponent {


### PR DESCRIPTION
[LRQA-66891](https://issues.liferay.com/browse/LRQA-66891) - _Refactor Web Content Administration macros to stop waiting for Metal component_

This PR is intended to experiment the refactor of removing the wait for metal components on browser to be ready, following the deprecation of Metal JS