### PR TITLE
Testmap Textfield 0709

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -161,9 +161,33 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test CanDefalutSearchablePropertyBeKeyword {
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
 
-		// TODO pending implementation
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Web Content",
+			configurationName = "Administration",
+			configurationScope = "System Scope");
 
+		FormFields.viewCheckboxChecked(fieldName = "Structure Fields Indexable Enable");
+
+		SystemSettings.saveConfiguration();
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+		NavItem.gotoStructures();
+
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.viewFieldSearchable(
+			fieldFieldLabel = "Text",
+			searchableType = "Keyword");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -24,7 +24,7 @@ definition {
 		}
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify that is possible to delete the field"
 	@priority = "5"
 	test CanBeDeleted {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -54,7 +54,7 @@ definition {
 		DataEngine.assertFieldNotPresent(fieldFieldLabel = "Text");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify that is possible to duplicate the field"
 	@priority = "4"
 	test CanBeDuplicated {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -86,7 +86,7 @@ definition {
 			fieldName = "Text");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify that Label and Help text can be edited"
 	@priority = "5"
 	test CanBeEdited {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -98,11 +98,10 @@ definition {
 		DataEngine.addField(
 			fieldFieldLabel = "Text",
 			fieldName = "Text");
-		
+
 		DataEngine.editFieldTip(
 			fieldFieldLabel = "Text",
 			fieldHelp = "Help Text");
-
 
 		WebContentStructures.saveCP();
 
@@ -126,7 +125,7 @@ definition {
 			fieldName = "Text");
 	}
 
-	@description = "Verify that Label, Placeholder text and Help text can be set"
+	@description = "Verify that Text field can be set as Single line or Multiple line"
 	@priority = "3"
 	test CanBeSingleLineMultipleLine {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -164,7 +163,7 @@ definition {
 			fieldlineType = "Single Line");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify Default Searchable property is Disable when System Setting is left unchecked"
 	@priority = "3"
 	test CanDefalutSearchablePropertyBeDisabled {
 		ApplicationsMenu.gotoPortlet(
@@ -196,8 +195,7 @@ definition {
 			searchableType = "Disable");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "Verify Default Searchable property is Keyword when System Setting is checked"
 	@priority = "3"
 	test CanDefalutSearchablePropertyBeKeyword {
 		ApplicationsMenu.gotoPortlet(
@@ -229,7 +227,7 @@ definition {
 			searchableType = "Keyword");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify that Label, Placeholder text and Help text can be set"
 	@priority = "5"
 	test CanSetLabelPlaceholderAndHelpText {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -262,7 +260,7 @@ definition {
 			fieldPlaceholder = "Placeholder Text");
 	}
 
-	@description = "This is a stubbed description"
+	@description = "Verify that Label can be shown/hidden"
 	@priority = "3"
 	test CanSetLabelToShownHidden {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -98,6 +98,11 @@ definition {
 		DataEngine.addField(
 			fieldFieldLabel = "Text",
 			fieldName = "Text");
+		
+		DataEngine.editFieldTip(
+			fieldFieldLabel = "Text",
+			fieldHelp = "Help Text");
+
 
 		WebContentStructures.saveCP();
 
@@ -107,17 +112,21 @@ definition {
 			fieldFieldLabel = "Text",
 			fieldFieldLabelEdit = "Text Edited");
 
+		DataEngine.editFieldTip(
+			fieldFieldLabel = "Text Edited",
+			fieldHelp = "Help Text Edited");
+
 		WebContentStructures.saveCP();
 
 		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
 
 		DataEngine.viewField(
 			fieldFieldLabel = "Text Edited",
+			fieldHelp = "Help Text Edited",
 			fieldName = "Text");
 	}
 
-	@description = "This is a stubbed description"
-	@ignore = "true"
+	@description = "Verify that Label, Placeholder text and Help text can be set"
 	@priority = "3"
 	test CanBeSingleLineMultipleLine {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -27,25 +27,7 @@ definition {
 	@description = "This is a stubbed description"
 	@ignore = "true"
 	@priority = "5"
-	test CanSetLabelPlaceholderAndHelpText {
-
-		// TODO pending implementation
-
-	}
-
-	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "3"
-	test CanSetLabelBeShownHidden {
-
-		// TODO pending implementation
-
-	}
-
-	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "3"
-	test CanBeSingleLineMultipleLine {
+	test CanBeDeleted {
 
 		// TODO pending implementation
 
@@ -62,31 +44,71 @@ definition {
 
 	@description = "This is a stubbed description"
 	@ignore = "true"
+	@priority = "3"
+	test CanBeSingleLineMultipleLine {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanDefalutSearchablePropertyBeDisabled {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanDefalutSearchablePropertyBeKeyword {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanSetLabelBeShownHidden {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
 	@priority = "5"
-	test CanBeDeleted {
+	test CanSetLabelPlaceholderAndHelpText {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.editFieldTip(
+			fieldFieldLabel = "Text",
+			fieldHelp = "Help Text",
+			fieldPlaceholder = "Placeholder Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Text",
+			fieldHelp = "Help Text",
+			fieldName = "Text",
+			fieldPlaceholder = "Placeholder Text");
 	}
-
-	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "3"
-	test CanDefalutSearchablePropertyBeDisabled{
-
-		// TODO pending implementation
-
-	}
-
-	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "3"
-	test CanDefalutSearchablePropertyBeKeyword{
-
-		// TODO pending implementation
-
-	}
-
-
 
 }

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -126,12 +126,35 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "3"
 	test CanDefalutSearchablePropertyBeDisabled {
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "System Settings");
 
-		// TODO pending implementation
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Web Content",
+			configurationName = "Administration",
+			configurationScope = "System Scope");
 
+		FormFields.disableCheckbox(fieldName = "Structure Fields Indexable Enable");
+
+		SystemSettings.saveConfiguration();
+
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+		NavItem.gotoStructures();
+
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.viewFieldSearchable(
+			fieldFieldLabel = "Text",
+			searchableType = "Disable");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -103,9 +103,33 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test CanSetLabelBeShownHidden {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.toggleShowLabel(fieldLabel = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.assertFieldNotPresent(fieldFieldLabel = "Text");
+
+		DataEngine.toggleShowLabel();
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -28,9 +28,31 @@ definition {
 	@ignore = "true"
 	@priority = "5"
 	test CanBeDeleted {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Numeric",
+			fieldName = "Numeric");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.delete(fieldFieldLabel = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.assertFieldNotPresent(fieldFieldLabel = "Text");
 	}
 
 	@description = "This is a stubbed description"
@@ -100,39 +122,6 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "3"
-	test CanSetLabelBeShownHidden {
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(structureName = "WC Structure Title");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Text",
-			fieldName = "Text");
-
-		DataEngine.toggleShowLabel(fieldLabel = "Text");
-
-		WebContentStructures.saveCP();
-
-		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
-
-		DataEngine.assertFieldNotPresent(fieldFieldLabel = "Text");
-
-		DataEngine.toggleShowLabel();
-
-		WebContentStructures.saveCP();
-
-		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
-
-		DataEngine.viewField(
-			fieldFieldLabel = "Text",
-			fieldName = "Text");
-	}
-
-	@description = "This is a stubbed description"
 	@priority = "5"
 	test CanSetLabelPlaceholderAndHelpText {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -163,6 +152,38 @@ definition {
 			fieldHelp = "Help Text",
 			fieldName = "Text",
 			fieldPlaceholder = "Placeholder Text");
+	}
+
+	@description = "This is a stubbed description"
+	@priority = "3"
+	test CanSetLabelToShownHidden {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+		NavItem.gotoStructures();
+
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.toggleShowLabel(fieldLabel = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.assertFieldNotPresent(fieldFieldLabel = "Text");
+
+		DataEngine.toggleShowLabel();
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
 	}
 
 }

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -26,11 +26,67 @@ definition {
 
 	@description = "This is a stubbed description"
 	@ignore = "true"
-	@priority = "3"
+	@priority = "5"
 	test CanSetLabelPlaceholderAndHelpText {
 
 		// TODO pending implementation
 
 	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanSetLabelBeShownHidden {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanBeSingleLineMultipleLine {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "4"
+	test CanBeDuplicated {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "5"
+	test CanBeDeleted {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanDefalutSearchablePropertyBeDisabled{
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
+	@priority = "3"
+	test CanDefalutSearchablePropertyBeKeyword{
+
+		// TODO pending implementation
+
+	}
+
+
 
 }

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -120,9 +120,39 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test CanBeSingleLineMultipleLine {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.editFieldType(
+			fieldFieldLabel = "Text",
+			fieldlineType = "Multiple Lines");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewFieldType(
+			fieldFieldLabel = "Text",
+			fieldlineType = "Multiple Lines");
+
+		DataEngine.editFieldType(
+			fieldFieldLabel = "Text",
+			fieldlineType = "Single Line");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewFieldType(
+			fieldFieldLabel = "Text",
+			fieldlineType = "Single Line");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -25,7 +25,6 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "5"
 	test CanBeDeleted {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -56,12 +55,35 @@ definition {
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
 	@priority = "4"
 	test CanBeDuplicated {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.duplicate(fieldFieldLabel = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Copy of Text",
+			fieldName = "Text");
 	}
 
 	@description = "This is a stubbed description"

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -35,6 +35,15 @@ definition {
 
 	@description = "This is a stubbed description"
 	@ignore = "true"
+	@priority = "5"
+	test CanBeEdited {
+
+		// TODO pending implementation
+
+	}
+
+	@description = "This is a stubbed description"
+	@ignore = "true"
 	@priority = "4"
 	test CanBeDuplicated {
 

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/fields/DETextField.testcase
@@ -35,20 +35,41 @@ definition {
 
 	@description = "This is a stubbed description"
 	@ignore = "true"
-	@priority = "5"
-	test CanBeEdited {
+	@priority = "4"
+	test CanBeDuplicated {
 
 		// TODO pending implementation
 
 	}
 
 	@description = "This is a stubbed description"
-	@ignore = "true"
-	@priority = "4"
-	test CanBeDuplicated {
+	@priority = "5"
+	test CanBeEdited {
+		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 
-		// TODO pending implementation
+		NavItem.gotoStructures();
 
+		WebContentStructures.addCP(structureName = "WC Structure Title");
+
+		DataEngine.addField(
+			fieldFieldLabel = "Text",
+			fieldName = "Text");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.editFieldLabel(
+			fieldFieldLabel = "Text",
+			fieldFieldLabelEdit = "Text Edited");
+
+		WebContentStructures.saveCP();
+
+		WebContentNavigator.gotoEditStructure(structureName = "WC Structure Title");
+
+		DataEngine.viewField(
+			fieldFieldLabel = "Text Edited",
+			fieldName = "Text");
 	}
 
 	@description = "This is a stubbed description"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -1107,6 +1107,7 @@ definition {
 
 		if (isSet(fieldPlaceholder)) {
 			var key_fieldFieldLabel = "${fieldFieldLabel}";
+			key_fieldLabel = "Placeholder";
 			var key_text = "Placeholder";
 
 			Click(locator1 = "Sidebar#DDM_ANY");
@@ -1116,7 +1117,7 @@ definition {
 				value1 = "${fieldPlaceholder}");
 
 			AssertTextEquals(
-				locator1 = "DDMEditStructure#SETTINGS_TEXT",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
 				value1 = "${fieldPlaceholder}");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -1001,21 +1001,6 @@ definition {
 		Click(locator1 = "Sidebar#BACK");
 	}
 
-	macro editFieldType{
-		AssertClick.assertPartialTextClickAt(
-			key_fieldFieldLabel = "${fieldFieldLabel}",
-			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
-			value1 = "${fieldFieldLabel}");
-
-		Check.checkNotVisible(
-			key_fieldFieldLabel = "Field Type",
-			key_optionValue = "${fieldType}",
-			locator1 = "WCEditWebContent#SELECTION_OPTION");
-
-		Click(locator1 = "Sidebar#BACK");
-	}
-
-
 	macro editFieldsetsCollapsible {
 		Click(
 			key_fieldsetLabel = "${fieldsetLabel}",
@@ -1162,6 +1147,20 @@ definition {
 					value1 = "${fieldHelp}");
 			}
 		}
+
+		Click(locator1 = "Sidebar#BACK");
+	}
+
+	macro editFieldType {
+		AssertClick.assertPartialTextClickAt(
+			key_fieldFieldLabel = "${fieldFieldLabel}",
+			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
+			value1 = "${fieldFieldLabel}");
+
+		Check.checkNotVisible(
+			key_fieldFieldLabel = "Field Type",
+			key_optionValue = "${fieldlineType}",
+			locator1 = "WCEditWebContent#SELECTION_OPTION");
 
 		Click(locator1 = "Sidebar#BACK");
 	}
@@ -1434,18 +1433,6 @@ definition {
 			locator1 = "WCEditWebContent#SELECTION_OPTION");
 	}
 
-	macro viewFieldType {
-		AssertClick.assertPartialTextClickAt(
-			key_fieldFieldLabel = "${fieldFieldLabel}",
-			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
-			value1 = "${fieldFieldLabel}");
-
-		AssertChecked.assertCheckedNotVisible(
-			key_fieldFieldLabel = "Field Type",
-			key_optionValue = "${fieldType}",
-			locator1 = "WCEditWebContent#SELECTION_OPTION");
-	}
-
 	macro viewFieldset {
 		AssertVisible(
 			key_fieldsetLabel = "${fieldsetName}",
@@ -1471,6 +1458,18 @@ definition {
 					locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER_LABEL");
 			}
 		}
+	}
+
+	macro viewFieldType {
+		AssertClick.assertPartialTextClickAt(
+			key_fieldFieldLabel = "${fieldFieldLabel}",
+			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
+			value1 = "${fieldFieldLabel}");
+
+		AssertChecked.assertCheckedNotVisible(
+			key_fieldFieldLabel = "Field Type",
+			key_optionValue = "${fieldlineType}",
+			locator1 = "WCEditWebContent#SELECTION_OPTION");
 	}
 
 	macro viewNestedField {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -1374,6 +1374,15 @@ definition {
 				locator1 = "DDMEditStructure#SETTINGS_TEXT",
 				value1 = "${fieldHelp}");
 		}
+		if (isSet(fieldPlaceholder)) {
+			key_fieldLabel = "Placeholder";
+
+			Click(locator1 = "Sidebar#DDM_ANY");
+
+			AssertTextEquals(
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "${fieldPlaceholder}");
+		}
 	}
 
 	macro viewFieldReference {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -1374,6 +1374,7 @@ definition {
 				locator1 = "DDMEditStructure#SETTINGS_TEXT",
 				value1 = "${fieldHelp}");
 		}
+
 		if (isSet(fieldPlaceholder)) {
 			key_fieldLabel = "Placeholder";
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -1001,6 +1001,21 @@ definition {
 		Click(locator1 = "Sidebar#BACK");
 	}
 
+	macro editFieldType{
+		AssertClick.assertPartialTextClickAt(
+			key_fieldFieldLabel = "${fieldFieldLabel}",
+			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
+			value1 = "${fieldFieldLabel}");
+
+		Check.checkNotVisible(
+			key_fieldFieldLabel = "Field Type",
+			key_optionValue = "${fieldType}",
+			locator1 = "WCEditWebContent#SELECTION_OPTION");
+
+		Click(locator1 = "Sidebar#BACK");
+	}
+
+
 	macro editFieldsetsCollapsible {
 		Click(
 			key_fieldsetLabel = "${fieldsetLabel}",
@@ -1416,6 +1431,18 @@ definition {
 		AssertChecked.assertCheckedNotVisible(
 			key_fieldFieldLabel = "Searchable",
 			key_optionValue = "${searchableType}",
+			locator1 = "WCEditWebContent#SELECTION_OPTION");
+	}
+
+	macro viewFieldType {
+		AssertClick.assertPartialTextClickAt(
+			key_fieldFieldLabel = "${fieldFieldLabel}",
+			locator1 = "DDMEditStructure#FORM_FIELD_CONTAINER",
+			value1 = "${fieldFieldLabel}");
+
+		AssertChecked.assertCheckedNotVisible(
+			key_fieldFieldLabel = "Field Type",
+			key_optionValue = "${fieldType}",
 			locator1 = "WCEditWebContent#SELECTION_OPTION");
 	}
 


### PR DESCRIPTION
- LRQA-68539 Add tests stubs
- LRQA-68539 Fix editFieldTip macro on placeholder
- LRQA-68539 Fix viewField macro by adding a placeholder condition
- LRQA-68539 Add CanSetLabelPlaceholderAndHelpText test
- LRQA-68539 Add CanBeEdited stub
- LRQA-68539 Add CanBeEdited test
- LRQA-68539 Add CanSetLabelBeShownHidden test
- LRQA-68539 Add CanBeDeleted test
- LRQA-68539 Add CanBeDuplicated test
- LRQA-68539 Add CanDefalutSearchablePropertyBeDisabled test
- LRQA-68539 Add CanDefalutSearchablePropertyBeKeyword test
- LRQA-68539 Add editFieldType and viewFieldType macros
- LRQA-68539 Add CanBeSingleLineMultipleLine test
- LRQA-68539 Fix CanBeEdited test
- LRQA-68539 Add test descriptions
